### PR TITLE
Fixes missing export in action.lua

### DIFF
--- a/action.lua
+++ b/action.lua
@@ -237,5 +237,6 @@ return {
     deweed = deweed,
     transplant = transplant,
     transplantToMultifarm = transplantToMultifarm,
-    destroyAll = destroyAll
+    destroyAll = destroyAll,
+    dumpInventory = dumpInventory,
 }


### PR DESCRIPTION
action.dumpInventory is called in autoStat.lua but was not exported, which would cause error when autoStat is done (https://github.com/huchenlei/auto-crossbreeding/blob/8a5b9d46341ff6de0d2ac064fec7e5a79ed307bc/autoStat.lua#L147)